### PR TITLE
Fix RSS feed sorting by publication date

### DIFF
--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -8,11 +8,13 @@ export async function GET(context) {
     title: SITE.title,
     description: SITE.description,
     site: context.site,
-    items: blog.map((post) => ({
-      title: post.data.title,
-      description: post.data.description,
-      pubDate: post.data.publicationDate,
-      link: `/blog/${post.id}`,
-    })),
+    items: blog
+      .sort((a, b) => b.data.publicationDate.valueOf() - a.data.publicationDate.valueOf())
+      .map((post) => ({
+        title: post.data.title,
+        description: post.data.description,
+        pubDate: post.data.publicationDate,
+        link: `/blog/${post.id}`,
+      })),
   });
 }


### PR DESCRIPTION
Sort blog posts by publication date (newest first) before mapping to RSS items. This ensures RSS readers display posts in chronological order rather than arbitrary order.

Uses the same sorting pattern as Posts.astro component for consistency.