### PR TITLE
fix og:image and twitter:image fallback logic

### DIFF
--- a/src/components/SeoPost.astro
+++ b/src/components/SeoPost.astro
@@ -19,7 +19,7 @@ const ogImage = new URL("./og.jpg", Astro.site);
 <meta property="og:description" content={postDescription} />
 <meta
   property="og:image"
-  content={`${SITE.href}${post?.data?.image?.src}` || ogImage}
+  content={post?.data?.image?.src ? `${SITE.href}${post.data.image.src}` : ogImage}
 />
 <meta property="og:image:alt" content={postTitle} />
 <meta property="og:type" content="website" />
@@ -29,7 +29,7 @@ const ogImage = new URL("./og.jpg", Astro.site);
 <meta name="twitter:description" content={postDescription} />
 <meta
   property="twitter:image"
-  content={`${SITE.href}${post?.data?.image?.src}` || ogImage}
+  content={post?.data?.image?.src ? `${SITE.href}${post.data.image.src}` : ogImage}
 />
 <meta name="twitter:image:alt" content={postTitle} />
 <meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
Replace broken || operator with ternary to properly handle missing post images. When post.data.image.src is undefined, the previous logic produced a truthy string "https://example.com/undefined" instead of using the ogImage fallback.